### PR TITLE
Requirements for modules updated and pyinform excluded from the requirements 

### DIFF
--- a/EEGExtract.py
+++ b/EEGExtract.py
@@ -8,7 +8,6 @@ import dit
 import librosa
 import statsmodels.api as sm
 import itertools
-from pyinform import mutualinfo
 from statsmodels import tsa
 from sklearn.metrics import mutual_info_score
 import numpy as np
@@ -212,7 +211,7 @@ def mfcc(eegData,fs,order=2):
     H = np.zeros((eegData.shape[0], eegData.shape[2],order))
     for chan in range(H.shape[0]):
         for epoch in range(H.shape[1]):
-            H[chan, epoch, : ] = librosa.feature.mfcc(np.asfortranarray(eegData[chan,:,epoch]), sr=fs)[0:order].T
+            H[chan, epoch, : ] = librosa.feature.mfcc(y=np.asfortranarray(eegData[chan,:,epoch]), sr=fs)[0:order].T
     return H
 
 ##########
@@ -340,8 +339,9 @@ def arma(eegData,order=2):
     H = np.zeros((eegData.shape[0], eegData.shape[2],order))
     for chan in range(H.shape[0]):
         for epoch in range(H.shape[1]):
-            arma_mod = sm.tsa.ARMA(eegData[chan,:,epoch], order=(order,order))
-            arma_res = arma_mod.fit(trend='nc', disp=-1)
+            # ARMA is deprecated, use ARIMA with d=0 instead
+            arma_mod = sm.tsa.ARIMA(eegData[chan,:,epoch], order=(order, 0, order), trend='n')
+            arma_res = arma_mod.fit(method_kwargs={'disp': False})
             H[chan, epoch, : ] = arma_res.arparams
     return H
 

--- a/example.ipynb
+++ b/example.ipynb
@@ -2,10 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
     "import EEGExtract as eeg\n",
     "import glob\n",
     "import numpy as np"
@@ -13,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,14 +73,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "trials = []\n",
     "classes = []\n",
     "artifacts = []\n",
-    "for file in glob.glob('../bcidatasetIV2a/*.npz'):\n",
+    "for file in glob.glob('../EEGExtract/bcidatasetIV2a/*.npz'):\n",
     "    datasetA1 = MotorImageryDataset(file)\n",
     "    # trials contains the N valid trials, and clases its related class.\n",
     "    tmp_trials, tmp_classes, tmp_artifacts = datasetA1.get_trials_from_channel()\n",
@@ -89,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +118,7 @@
        "(22, 500, 2816)"
       ]
      },
-     "execution_count": 135,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -128,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,17 +156,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
     "#Tsalis Entropy (n=10)\n",
-    "tsalisRes = eeg.tsalisEntropy(eegData, bin_min=-200, bin_max=200, binWidth=2,list(range(1,10+1)))"
+    "tsalisRes = eeg.tsalisEntropy(eegData, bin_min=-200, bin_max=200, binWidth=2,orders=list(range(1,10+1)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,9 +190,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alperen/miniconda3/envs/eegextract/lib/python3.11/site-packages/librosa/core/spectrum.py:266: UserWarning: n_fft=2048 is too large for input signal of length=500\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "# Cepstrum Coefficients (n=2)\n",
     "CepstrumRes = eeg.mfcc(eegData, fs,order=2)"
@@ -215,7 +226,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/sarisadiya/Projects/ECC/EEGExtract/EEGExtract.py:256: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "/Users/alperen/Documents/Goethe/PhD/HONDA/eegextract_trial/EEGExtract.py:243: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
       "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
       "  (p, r1, r2, s)=np.linalg.lstsq(x, L)\n"
      ]
@@ -228,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,9 +400,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alperen/miniconda3/envs/eegextract/lib/python3.11/site-packages/numpy/core/fromnumeric.py:3464: RuntimeWarning: Mean of empty slice.\n",
+      "  return _methods._mean(a, axis=axis, dtype=dtype,\n",
+      "/Users/alperen/miniconda3/envs/eegextract/lib/python3.11/site-packages/numpy/core/_methods.py:269: RuntimeWarning: Degrees of freedom <= 0 for slice\n",
+      "  ret = _var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,\n"
+     ]
+    }
+   ],
    "source": [
     "# Burst length μ and σ\n",
     "burstLenMean_res,burstLenStd_res = eeg.burstLengthStats(eegData,fs)"
@@ -399,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 256,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 300,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 319,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 361,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +468,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 362,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 507,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 508,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 509,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -509,7 +531,7 @@
        "(2816, 396)"
       ]
      },
-     "execution_count": 509,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -520,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 510,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -529,7 +551,7 @@
        "18"
       ]
      },
-     "execution_count": 510,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -540,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 511,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -549,7 +571,7 @@
        "0.17329545454545456"
       ]
      },
-     "execution_count": 511,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -560,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 512,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 513,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -580,7 +602,7 @@
        "HBOS(alpha=0.07, contamination=0.15, n_bins=17, tol=0.5)"
       ]
      },
-     "execution_count": 513,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -592,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 523,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,17 +623,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 524,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[2018,  310],\n",
-       "       [ 375,  113]])"
+       "array([[2025,  303],\n",
+       "       [ 368,  120]])"
       ]
      },
-     "execution_count": 524,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -622,16 +644,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 525,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.10386299272297506"
+       "0.12217820163082671"
       ]
      },
-     "execution_count": 525,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -642,16 +664,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 526,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.24807903402854006"
+       "0.26344676180021953"
       ]
      },
-     "execution_count": 526,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -666,11 +688,18 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "eegextract",
    "language": "python",
    "name": "python3"
   },
@@ -684,7 +713,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-dit==1.2.3
-numpy==1.17.2
-pandas==0.25.1
-PyWavelets==1.0.3
-scikit-learn==0.21.3
-scipy==1.3.1
-statsmodels==0.10.1
-pyod==0.8.1 #For the example
+dit==1.5
+numpy==1.24.3
+pandas==2.0.1
+PyWavelets==1.8.0
+scikit-learn==1.7.2
+scipy==1.15.3
+statsmodels==0.14.5
+pyod==2.0.5
+librosa==0.11.0


### PR DESCRIPTION
- Pyinform is not used in any functionalities. It is also problematic to install, especially in newer versions of macOS. 
- ARMA function is not available in newer versions of the stats module. The ARIMA function has been adapted to use as ARMA.
- Some examples have been updated to make sure it is working with new versions of external modules.